### PR TITLE
delete airflow.cfg

### DIFF
--- a/beniflow/dags/airflow.cfg
+++ b/beniflow/dags/airflow.cfg
@@ -1,1 +1,0 @@
-/Users/benjaminbang/dev/ben_prv/airflow_works/beniflow/dags/airflow.cfg.template


### PR DESCRIPTION
`airflow.cfg` file was breaking the build of the master due to symlink using local directories.